### PR TITLE
add inngest base url to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,4 +14,4 @@ CLERK_SECRET_KEY=your_API_key
 # completely not obligatory
 OPENAI_API_KEY=your_OpenAI_key
 
-INNGEST_BASE_URL="http://127.0.0.1:8288"
+INNGEST_DEV=1

--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,5 @@ CLERK_SECRET_KEY=your_API_key
 
 # completely not obligatory
 OPENAI_API_KEY=your_OpenAI_key
+
+INNGEST_BASE_URL="http://127.0.0.1:8288"


### PR DESCRIPTION
With Inngest running locally, we encountered this error:

```
 GET /?message=beep+bloop+boop 200 in 114ms
 ⨯ Error: Inngest API Error: 401 Event key not found
    at async create (./app/page.tsx:31:5)
```
which seems to be the same as https://github.com/inngest/inngest/issues/821
The proposed workaround, which also worked for us, is to specify the INNGEST_BASE_URL when running locally.